### PR TITLE
Added docs-template via git upload

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs_template.md
+++ b/.github/ISSUE_TEMPLATE/docs_template.md
@@ -1,0 +1,8 @@
+## New or Exisiting ?
+<!-- Is this an issue with current documentation or do do we need to create new documentation -->
+
+## Describe what is needed ?
+<!-- Describe the documentation need   -->
+
+## Where does/should the documentation currently live
+<!-- Is this documentation a tutorial, part of a docstring, ect?      -->


### PR DESCRIPTION
added the docs template via git upload. Its seems as if the merged PR didn't work last night and this is placing the file in the same folder as the other templates.